### PR TITLE
Add GetRecords method to transactions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,6 @@ linters:
   enable-all: true
   disable:
     - depguard
-    - godot
     - gochecknoinits
     - gochecknoglobals
     - nlreturn

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,7 +36,10 @@ linters:
   enable-all: true
   disable:
     - depguard
+    - godot
     - gochecknoinits
     - gochecknoglobals
+    - nlreturn
     - lll
     - prealloc
+    - testpackage

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,5 @@ linters:
     - depguard
     - gochecknoinits
     - gochecknoglobals
-    - nlreturn
     - lll
     - prealloc
-    - testpackage

--- a/v2/eventsource/event_test.go
+++ b/v2/eventsource/event_test.go
@@ -8,11 +8,13 @@ import (
 )
 
 func Test_Getters(t *testing.T) {
-	var aggID = "123"
-	var userID = "testUser"
-	var ulid = "ULID"
-	var timestamp int64 = 123
-	var testEvent = BaseEvent{aggID, userID, ulid, timestamp}
+	var (
+		aggID           = "123"
+		userID          = "testUser"
+		ulid            = "ULID"
+		timestamp int64 = 123
+		testEvent       = BaseEvent{aggID, userID, ulid, timestamp}
+	)
 
 	assert.Equal(t, aggID, testEvent.GetAggregateID())
 	assert.Equal(t, testEvent.AggregateID, testEvent.GetAggregateID())
@@ -25,13 +27,15 @@ func Test_Getters(t *testing.T) {
 }
 
 func Test_Setters(t *testing.T) {
-	var aggID = "123"
-	var userID = "testUser"
-	var ulid = "ULID"
-	var ulid2 = "CHANGCED_ULID"
-	var timestamp int64 = 123
-	var timestamp2 int64 = 456
-	var testEvent = BaseEvent{aggID, userID, ulid, timestamp}
+	var (
+		aggID            = "123"
+		userID           = "testUser"
+		ulid             = "ULID"
+		ulid2            = "CHANGCED_ULID"
+		timestamp  int64 = 123
+		timestamp2 int64 = 456
+		testEvent        = BaseEvent{aggID, userID, ulid, timestamp}
+	)
 
 	testEvent.SetSequenceID(ulid2)
 	testEvent.SetTimestamp(timestamp2)
@@ -43,13 +47,15 @@ func Test_GetTypeName(t *testing.T) {
 	type TestEvent struct {
 		*BaseEvent
 	}
-	var tests = []struct {
+
+	tests := []struct {
 		event Event
 		name  string
 	}{
 		{TestEvent{}, "TestEvent"},
 		{&TestEvent{}, "TestEvent"},
 	}
+
 	for _, test := range tests {
 		typeName := GetTypeName(test.event)
 		if strings.Compare(typeName, test.name) != 0 {

--- a/v2/eventsource/mock.go
+++ b/v2/eventsource/mock.go
@@ -6,190 +6,204 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// SerializerMock is a mock
+// SerializerMock is a mock.
 type SerializerMock struct {
 	*mock.Mock
 }
 
-// CreateSerializerMock returns a serializerMock
+// CreateSerializerMock returns a serializerMock.
 func CreateSerializerMock() *SerializerMock {
 	return &SerializerMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// StoreMock is a mock
+// StoreMock is a mock.
 type StoreMock struct {
 	*mock.Mock
 }
 
-// CreateStoreMock returns a storeMock
+// CreateStoreMock returns a storeMock.
 func CreateStoreMock() *StoreMock {
 	return &StoreMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// AggregatorMock is a mock
+// AggregatorMock is a mock.
 type AggregatorMock struct {
 	Mock *mock.Mock
 }
 
-// CreateAggregatorMock returns a aggregatorMock
+// CreateAggregatorMock returns an aggregatorMock.
 func CreateAggregatorMock() *AggregatorMock {
 	return &AggregatorMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// Unmarshal parses the JSON-encoded data and returns an event
+// Unmarshal parses the JSON-encoded data and returns an event.
 func (o SerializerMock) Unmarshal(data []byte, eventType string) (event Event, err error) {
 	args := o.Called(data, eventType)
+
 	return args.Get(0).(Event), args.Error(1)
 }
 
 // Marshal returns the JSON encoding of event.
 func (o SerializerMock) Marshal(event Event) (data []byte, err error) {
 	args := o.Called(event)
+
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-// StoreTransactionMock is a mock
+// StoreTransactionMock is a mock.
 type StoreTransactionMock struct {
 	*mock.Mock
 }
 
-// CreateStoreTransactionMock returns a store transaction mock
+// CreateStoreTransactionMock returns a store transaction mock.
 func CreateStoreTransactionMock() *StoreTransactionMock {
 	return &StoreTransactionMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// Commit is a mock
+// Commit is a mock.
 func (o StoreTransactionMock) Commit() error {
 	args := o.Called()
+
 	return args.Error(0)
 }
 
-// Rollback is a mock
+// Rollback is a mock.
 func (o StoreTransactionMock) Rollback() error {
 	args := o.Called()
+
 	return args.Error(0)
 }
 
-// NewTransaction is a mock
+// GetRecords is a mock.
+func (o StoreTransactionMock) GetRecords() []Record {
+	args := o.Called()
+
+	return args.Get(0).([]Record)
+}
+
+// NewTransaction is a mock.
 func (o StoreMock) NewTransaction(ctx context.Context, records ...Record) (StoreTransaction, error) {
 	args := o.Called(ctx, records)
+
 	return args.Get(0).(StoreTransaction), args.Error(1)
 }
 
-// LoadByAggregate is a mock
+// LoadByAggregate is a mock.
 func (o StoreMock) LoadByAggregate(ctx context.Context, aggregateID string, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, aggregateID, opts)
+
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadBySequenceID is a mock
+// LoadBySequenceID is a mock.
 func (o StoreMock) Load(ctx context.Context, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, opts)
+
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadBySequenceID is a mock
+// LoadBySequenceID is a mock.
 func (o StoreMock) LoadBySequenceID(ctx context.Context, sequenceID string, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, sequenceID, opts)
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadBySequenceIDAndType is a mock
+// LoadBySequenceIDAndType is a mock.
 func (o StoreMock) LoadBySequenceIDAndType(ctx context.Context, sequenceID string, eventType string, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, sequenceID, eventType, opts)
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadByTimestamp is a mock
+// LoadByTimestamp is a mock.
 func (o StoreMock) LoadByTimestamp(ctx context.Context, timestamp int64, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, timestamp, opts)
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// On is a mock
+// On is a mock.
 func (o AggregatorMock) On(ctx context.Context, event Event) error {
 	args := o.Mock.Called(ctx, event)
 	return args.Error(0)
 }
 
-// SetAggregateID is not implemented
+// SetAggregateID is not implemented.
 func (o AggregatorMock) SetAggregateID(id string) {}
 
-// RepositoryMock is a mock
+// RepositoryMock is a mock.
 type RepositoryMock struct {
 	*mock.Mock
 }
 
-// CreateRepositoryMock returns a repositoryMock
+// CreateRepositoryMock returns a repositoryMock.
 func CreateRepositoryMock() *RepositoryMock {
 	return &RepositoryMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// Store is a mock
+// Store is a mock.
 func (r RepositoryMock) Store() Store {
 	args := r.Called()
 	return args.Get(0).(Store)
 }
 
-// Save is a mock
+// Save is a mock.
 func (r RepositoryMock) Save(ctx context.Context, events ...Event) error {
 	args := r.Called(ctx, events)
 	return args.Error(0)
 }
 
-// SaveTransaction is a mock
+// SaveTransaction is a mock.
 func (r RepositoryMock) SaveTransaction(ctx context.Context, events ...Event) (StoreTransaction, error) {
 	args := r.Called(ctx, events)
 	return args.Get(0).(StoreTransaction), args.Error(1)
 }
 
-// Load is a mock
+// Load is a mock.
 func (r RepositoryMock) Load(ctx context.Context, id string, aggr Aggregate) (deleted bool, err error) {
 	args := r.Called(ctx, id, aggr)
 	return args.Bool(0), args.Error(1)
 }
 
-//UnmarshalRecords is a mock
+// UnmarshalRecords is a mock.
 func (r RepositoryMock) UnmarshalRecords(records []Record) ([]Event, error) {
 	args := r.Called(records)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// LoadEvents is a mock
+// LoadEvents is a mock.
 func (r RepositoryMock) LoadEvents(ctx context.Context, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// GetEventsBySequenceID is a mock
+// GetEventsBySequenceID is a mock.
 func (r RepositoryMock) GetEventsBySequenceID(ctx context.Context, sequenceID string, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, sequenceID, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// GetEventsBySequenceIDAndType is a mock
+// GetEventsBySequenceIDAndType is a mock.
 func (r RepositoryMock) GetEventsBySequenceIDAndType(ctx context.Context, sequenceID string, eventType Event, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, sequenceID, eventType, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// GetEventsByTimestamp is a mock
+// GetEventsByTimestamp is a mock.
 func (r RepositoryMock) GetEventsByTimestamp(ctx context.Context, timestamp int64, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, timestamp, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// AddNotificationService is a mock
+// AddNotificationService is a mock.
 func (r RepositoryMock) AddNotificationService(service NotificationService) {
 	r.Called(service)
 }
@@ -198,7 +212,7 @@ type NotificationServiceMock struct {
 	*mock.Mock
 }
 
-// CreateNotificationServiceMock creates a notification service mock
+// CreateNotificationServiceMock creates a notification service mock.
 func CreateNotificationServiceMock() *NotificationServiceMock {
 	return &NotificationServiceMock{
 		Mock: &mock.Mock{},
@@ -210,6 +224,8 @@ func (ns NotificationServiceMock) Send(record Record) error {
 	return args.Error(0)
 }
 
-var _ Store = &StoreMock{}
-var _ Repository = &RepositoryMock{}
-var _ NotificationService = &NotificationServiceMock{}
+var (
+	_ Store               = &StoreMock{}
+	_ Repository          = &RepositoryMock{}
+	_ NotificationService = &NotificationServiceMock{}
+)

--- a/v2/eventsource/mock.go
+++ b/v2/eventsource/mock.go
@@ -6,204 +6,196 @@ import (
 	"github.com/stretchr/testify/mock"
 )
 
-// SerializerMock is a mock.
+// SerializerMock is a mock
 type SerializerMock struct {
 	*mock.Mock
 }
 
-// CreateSerializerMock returns a serializerMock.
+// CreateSerializerMock returns a serializerMock
 func CreateSerializerMock() *SerializerMock {
 	return &SerializerMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// StoreMock is a mock.
+// StoreMock is a mock
 type StoreMock struct {
 	*mock.Mock
 }
 
-// CreateStoreMock returns a storeMock.
+// CreateStoreMock returns a storeMock
 func CreateStoreMock() *StoreMock {
 	return &StoreMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// AggregatorMock is a mock.
+// AggregatorMock is a mock
 type AggregatorMock struct {
 	Mock *mock.Mock
 }
 
-// CreateAggregatorMock returns an aggregatorMock.
+// CreateAggregatorMock returns an aggregatorMock
 func CreateAggregatorMock() *AggregatorMock {
 	return &AggregatorMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// Unmarshal parses the JSON-encoded data and returns an event.
+// Unmarshal parses the JSON-encoded data and returns an event
 func (o SerializerMock) Unmarshal(data []byte, eventType string) (event Event, err error) {
 	args := o.Called(data, eventType)
-
 	return args.Get(0).(Event), args.Error(1)
 }
 
 // Marshal returns the JSON encoding of event.
 func (o SerializerMock) Marshal(event Event) (data []byte, err error) {
 	args := o.Called(event)
-
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-// StoreTransactionMock is a mock.
+// StoreTransactionMock is a mock
 type StoreTransactionMock struct {
 	*mock.Mock
 }
 
-// CreateStoreTransactionMock returns a store transaction mock.
+// CreateStoreTransactionMock returns a store transaction mock
 func CreateStoreTransactionMock() *StoreTransactionMock {
 	return &StoreTransactionMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// Commit is a mock.
+// Commit is a mock
 func (o StoreTransactionMock) Commit() error {
 	args := o.Called()
-
 	return args.Error(0)
 }
 
-// Rollback is a mock.
+// Rollback is a mock
 func (o StoreTransactionMock) Rollback() error {
 	args := o.Called()
-
 	return args.Error(0)
 }
 
-// GetRecords is a mock.
+// GetRecords is a mock
 func (o StoreTransactionMock) GetRecords() []Record {
 	args := o.Called()
-
 	return args.Get(0).([]Record)
 }
 
-// NewTransaction is a mock.
+// NewTransaction is a mock
 func (o StoreMock) NewTransaction(ctx context.Context, records ...Record) (StoreTransaction, error) {
 	args := o.Called(ctx, records)
-
 	return args.Get(0).(StoreTransaction), args.Error(1)
 }
 
-// LoadByAggregate is a mock.
+// LoadByAggregate is a mock
 func (o StoreMock) LoadByAggregate(ctx context.Context, aggregateID string, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, aggregateID, opts)
-
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadBySequenceID is a mock.
+// LoadBySequenceID is a mock
 func (o StoreMock) Load(ctx context.Context, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, opts)
-
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadBySequenceID is a mock.
+// LoadBySequenceID is a mock
 func (o StoreMock) LoadBySequenceID(ctx context.Context, sequenceID string, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, sequenceID, opts)
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadBySequenceIDAndType is a mock.
+// LoadBySequenceIDAndType is a mock
 func (o StoreMock) LoadBySequenceIDAndType(ctx context.Context, sequenceID string, eventType string, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, sequenceID, eventType, opts)
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// LoadByTimestamp is a mock.
+// LoadByTimestamp is a mock
 func (o StoreMock) LoadByTimestamp(ctx context.Context, timestamp int64, opts ...QueryOption) (record []Record, err error) {
 	args := o.Called(ctx, timestamp, opts)
 	return args.Get(0).([]Record), args.Error(1)
 }
 
-// On is a mock.
+// On is a mock
 func (o AggregatorMock) On(ctx context.Context, event Event) error {
 	args := o.Mock.Called(ctx, event)
 	return args.Error(0)
 }
 
-// SetAggregateID is not implemented.
+// SetAggregateID is not implemented
 func (o AggregatorMock) SetAggregateID(id string) {}
 
-// RepositoryMock is a mock.
+// RepositoryMock is a mock
 type RepositoryMock struct {
 	*mock.Mock
 }
 
-// CreateRepositoryMock returns a repositoryMock.
+// CreateRepositoryMock returns a repositoryMock
 func CreateRepositoryMock() *RepositoryMock {
 	return &RepositoryMock{
 		Mock: &mock.Mock{},
 	}
 }
 
-// Store is a mock.
+// Store is a mock
 func (r RepositoryMock) Store() Store {
 	args := r.Called()
 	return args.Get(0).(Store)
 }
 
-// Save is a mock.
+// Save is a mock
 func (r RepositoryMock) Save(ctx context.Context, events ...Event) error {
 	args := r.Called(ctx, events)
 	return args.Error(0)
 }
 
-// SaveTransaction is a mock.
+// SaveTransaction is a mock
 func (r RepositoryMock) SaveTransaction(ctx context.Context, events ...Event) (StoreTransaction, error) {
 	args := r.Called(ctx, events)
 	return args.Get(0).(StoreTransaction), args.Error(1)
 }
 
-// Load is a mock.
+// Load is a mock
 func (r RepositoryMock) Load(ctx context.Context, id string, aggr Aggregate) (deleted bool, err error) {
 	args := r.Called(ctx, id, aggr)
 	return args.Bool(0), args.Error(1)
 }
 
-// UnmarshalRecords is a mock.
+// UnmarshalRecords is a mock
 func (r RepositoryMock) UnmarshalRecords(records []Record) ([]Event, error) {
 	args := r.Called(records)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// LoadEvents is a mock.
+// LoadEvents is a mock
 func (r RepositoryMock) LoadEvents(ctx context.Context, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// GetEventsBySequenceID is a mock.
+// GetEventsBySequenceID is a mock
 func (r RepositoryMock) GetEventsBySequenceID(ctx context.Context, sequenceID string, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, sequenceID, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// GetEventsBySequenceIDAndType is a mock.
+// GetEventsBySequenceIDAndType is a mock
 func (r RepositoryMock) GetEventsBySequenceIDAndType(ctx context.Context, sequenceID string, eventType Event, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, sequenceID, eventType, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// GetEventsByTimestamp is a mock.
+// GetEventsByTimestamp is a mock
 func (r RepositoryMock) GetEventsByTimestamp(ctx context.Context, timestamp int64, opts ...QueryOption) ([]Event, error) {
 	args := r.Called(ctx, timestamp, opts)
 	return args.Get(0).([]Event), args.Error(1)
 }
 
-// AddNotificationService is a mock.
+// AddNotificationService is a mock
 func (r RepositoryMock) AddNotificationService(service NotificationService) {
 	r.Called(service)
 }
@@ -212,7 +204,7 @@ type NotificationServiceMock struct {
 	*mock.Mock
 }
 
-// CreateNotificationServiceMock creates a notification service mock.
+// CreateNotificationServiceMock creates a notification service mock
 func CreateNotificationServiceMock() *NotificationServiceMock {
 	return &NotificationServiceMock{
 		Mock: &mock.Mock{},

--- a/v2/eventsource/repository_test.go
+++ b/v2/eventsource/repository_test.go
@@ -256,6 +256,7 @@ func Test_RepoSaveSuccessNotification(t *testing.T) {
 	storeMock.On("NewTransaction", ctx, mock.MatchedBy(func(rs []Record) bool {
 		return len(rs) == 1 && matchRecord(rs[0], testEvent, testData)
 	})).Return(storeTransactionMock, nil).Once()
+	storeTransactionMock.On("GetRecords").Return([]Record{{UserID: testEvent.UserID, AggregateID: testEvent.AggregateID, Data: testData}}).Twice()
 	storeTransactionMock.On("Commit").Return(nil).Once()
 	notificationService.On("Send", mock.MatchedBy(func(r Record) bool {
 		return matchRecord(r, testEvent, testData)

--- a/v2/eventsource/stores/dynamodbstore/transaction.go
+++ b/v2/eventsource/stores/dynamodbstore/transaction.go
@@ -46,6 +46,7 @@ func (tx *transaction) Commit() (err error) {
 
 		tx.saved = append(tx.saved, record)
 	}
+
 	return
 }
 
@@ -64,4 +65,8 @@ func (tx *transaction) Rollback() error {
 	}
 
 	return nil
+}
+
+func (tx *transaction) GetRecords() []eventsource.Record {
+	return tx.records
 }

--- a/v2/eventsource/stores/memorystore/options.go
+++ b/v2/eventsource/stores/memorystore/options.go
@@ -8,16 +8,14 @@ import (
 
 type FilterFunc func(record eventsource.Record) bool
 
-var (
-	defaultOptions = &options{
-		sorter: func(records []eventsource.Record) {
-			sort.Slice(records, func(i, j int) bool {
-				return records[i].SequenceID < records[j].SequenceID
-			})
-		},
-		filters: []FilterFunc{},
-	}
-)
+var defaultOptions = &options{
+	sorter: func(records []eventsource.Record) {
+		sort.Slice(records, func(i, j int) bool {
+			return records[i].SequenceID < records[j].SequenceID
+		})
+	},
+	filters: []FilterFunc{},
+}
 
 type options struct {
 	sorter  func(records []eventsource.Record)
@@ -64,8 +62,10 @@ func ByTimestamp(timestamp int64) eventsource.QueryOption {
 func evaluateQueryOptions(opts []eventsource.QueryOption) *options {
 	copy := &options{}
 	*copy = *defaultOptions
+
 	for _, opt := range opts {
 		opt(copy)
 	}
+
 	return copy
 }

--- a/v2/eventsource/stores/memorystore/transaction.go
+++ b/v2/eventsource/stores/memorystore/transaction.go
@@ -37,6 +37,7 @@ func (tx *transaction) Rollback() error {
 		id := record.AggregateID
 		if rows, ok := tx.mem.Data[id]; ok {
 			newRows := []eventsource.Record{}
+
 			for _, row := range rows {
 				if row.SequenceID != record.SequenceID {
 					newRows = append(newRows, row)
@@ -52,4 +53,8 @@ func (tx *transaction) Rollback() error {
 	}
 
 	return nil
+}
+
+func (tx *transaction) GetRecords() []eventsource.Record {
+	return tx.records
 }

--- a/v2/eventsource/stores/sqlstore/options.go
+++ b/v2/eventsource/stores/sqlstore/options.go
@@ -34,7 +34,7 @@ type options struct {
 	where      map[column]whereOpt
 }
 
-// WithLimit will limit the result.
+// WithLimit will limit the result
 func WithLimit(limit int) eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -43,7 +43,7 @@ func WithLimit(limit int) eventsource.QueryOption {
 	}
 }
 
-// WithOffset will offset the result.
+// WithOffset will offset the result
 func WithOffset(offset int) eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -52,7 +52,7 @@ func WithOffset(offset int) eventsource.QueryOption {
 	}
 }
 
-// WithDescending will set the sorting order to descending.
+// WithDescending will set the sorting order to descending
 func WithDescending() eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -61,7 +61,7 @@ func WithDescending() eventsource.QueryOption {
 	}
 }
 
-// WithAscending will set the sorting order to ascending.
+// WithAscending will set the sorting order to ascending
 func WithAscending() eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -101,7 +101,7 @@ func ByType(value string) eventsource.QueryOption {
 	return equals(columnType, value)
 }
 
-// evaluate a list of options by extending the default options.
+// evaluate a list of options by extending the default options
 func evaluateQueryOptions(queryOpts []eventsource.QueryOption) *options {
 	opts := &options{
 		descending: false,

--- a/v2/eventsource/stores/sqlstore/options.go
+++ b/v2/eventsource/stores/sqlstore/options.go
@@ -4,12 +4,6 @@ import (
 	"github.com/SKF/go-eventsource/v2/eventsource"
 )
 
-var (
-	defaultOptions = &options{
-		descending: false,
-	}
-)
-
 type column string
 
 const (
@@ -40,7 +34,7 @@ type options struct {
 	where      map[column]whereOpt
 }
 
-// WithLimit will limit the result
+// WithLimit will limit the result.
 func WithLimit(limit int) eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -49,7 +43,7 @@ func WithLimit(limit int) eventsource.QueryOption {
 	}
 }
 
-// WithOffset will offset the result
+// WithOffset will offset the result.
 func WithOffset(offset int) eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -58,7 +52,7 @@ func WithOffset(offset int) eventsource.QueryOption {
 	}
 }
 
-// WithDescending will set the sorting order to descending
+// WithDescending will set the sorting order to descending.
 func WithDescending() eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -67,7 +61,7 @@ func WithDescending() eventsource.QueryOption {
 	}
 }
 
-// WithAscending will set the sorting order to ascending
+// WithAscending will set the sorting order to ascending.
 func WithAscending() eventsource.QueryOption {
 	return func(i interface{}) {
 		if o, ok := i.(*options); ok {
@@ -107,12 +101,16 @@ func ByType(value string) eventsource.QueryOption {
 	return equals(columnType, value)
 }
 
-// evaluate a list of options by extending the default options
-func evaluateQueryOptions(opts []eventsource.QueryOption) *options {
-	copy := &options{}
-	*copy = *defaultOptions
-	for _, opt := range opts {
-		opt(copy)
+// evaluate a list of options by extending the default options.
+func evaluateQueryOptions(queryOpts []eventsource.QueryOption) *options {
+	opts := &options{
+		descending: false,
+		where:      make(map[column]whereOpt),
 	}
-	return copy
+
+	for _, opt := range queryOpts {
+		opt(opts)
+	}
+
+	return opts
 }

--- a/v2/eventsource/stores/sqlstore/store.go
+++ b/v2/eventsource/stores/sqlstore/store.go
@@ -22,7 +22,7 @@ var (
 	loadSQL = "SELECT aggregate_id, sequence_id, created_at, user_id, type, data FROM %s"
 )
 
-// New creates a new event source store.
+// New creates a new event source store
 func New(db *sql.DB, tableName string) eventsource.Store {
 	return &store{
 		db:        db,
@@ -134,7 +134,7 @@ func (store *store) fetchRecords(ctx context.Context, queryOpts []eventsource.Qu
 	return records, err
 }
 
-// Load will load records based on specified query options.
+// Load will load records based on specified query options
 func (store *store) Load(ctx context.Context, opts ...eventsource.QueryOption) (records []eventsource.Record, err error) {
 	return store.fetchRecords(ctx, opts, loadSQL)
 }

--- a/v2/eventsource/stores/sqlstore/store.go
+++ b/v2/eventsource/stores/sqlstore/store.go
@@ -58,8 +58,8 @@ func (store *store) buildQuery(queryOpts []eventsource.QueryOption, query string
 			whereStatements = append(whereStatements, fmt.Sprintf("%s %s $%d", key, data.operator, len(args)))
 		}
 
-		whereQuery := "WHERE " + strings.Join(whereStatements, " AND ")
-		fullQuery = append(fullQuery, whereQuery)
+		whereQuery := strings.Join(whereStatements, " AND ")
+		fullQuery = append(fullQuery, "WHERE", whereQuery)
 	}
 
 	if opts.descending {

--- a/v2/eventsource/stores/sqlstore/store_test.go
+++ b/v2/eventsource/stores/sqlstore/store_test.go
@@ -158,11 +158,12 @@ func Test_SQLStoreE2E(t *testing.T) {
 
 	events, err := repo.LoadEvents(ctx, BySequenceID(""))
 	assert.NoError(t, err, "Could not get events")
-	assert.Equal(t, 8, len(events))
 
-	events, err = repo.LoadEvents(ctx, BySequenceID(events[len(events)-2].GetSequenceID()))
-	assert.NoError(t, err, "Could not get events")
-	assert.Equal(t, 1, len(events))
+	if assert.Equal(t, 8, len(events)) {
+		events, err = repo.LoadEvents(ctx, BySequenceID(events[len(events)-2].GetSequenceID()))
+		assert.NoError(t, err, "Could not get events")
+		assert.Equal(t, 1, len(events))
+	}
 }
 
 func Test_SQLStoreOptions(t *testing.T) {


### PR DESCRIPTION
This enables the API consumer to access the serialized records that were part of the transaction.