### PR TITLE
Allow user-defined event timestamps

### DIFF
--- a/v2/eventsource/repository.go
+++ b/v2/eventsource/repository.go
@@ -228,7 +228,10 @@ func (repo *repository) SaveTransaction(ctx context.Context, events ...Event) (S
 
 	for _, event := range events {
 		event.SetSequenceID(NewULID())
-		event.SetTimestamp(time.Now().UnixNano())
+
+		if event.GetTimestamp() == 0 {
+			event.SetTimestamp(time.Now().UnixNano())
+		}
 
 		data, err := repo.serializer.Marshal(event)
 		if err != nil {

--- a/v2/eventsource/repository_test.go
+++ b/v2/eventsource/repository_test.go
@@ -369,3 +369,43 @@ func Test_RepoMock_OK(t *testing.T) {
 	assert.EqualError(t, err, expectedError.Error())
 	assert.False(t, deleted)
 }
+
+func TestSaveTransaction_WithPredefinedTimestamp(t *testing.T) {
+	event := &BaseEvent{
+		AggregateID: "timestamp-test",
+		UserID:      "Kalle Banka",
+		SequenceID:  "0000XSNJG0MQJHBF4QX1EFD6Y3",
+		Timestamp:   1257894000000000000,
+	}
+
+	store, transaction, serializer, _ := setupMocks()
+	store.On("NewTransaction", mock.Anything, mock.Anything).Return(transaction, nil)
+	serializer.On("Marshal", mock.Anything).Return([]byte{1}, nil)
+
+	repo := NewRepository(store, serializer)
+
+	_, err := repo.SaveTransaction(context.Background(), event)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(1257894000000000000), event.Timestamp)
+}
+
+func TestSaveTransaction_TimestampZero(t *testing.T) {
+	event := &BaseEvent{
+		AggregateID: "timestamp-test",
+		UserID:      "Kalle Anka",
+		SequenceID:  "0000XSNJG0MQJHBF4QX1EFD6Y3",
+		Timestamp:   0,
+	}
+
+	store, transaction, serializer, _ := setupMocks()
+	store.On("NewTransaction", mock.Anything, mock.Anything).Return(transaction, nil)
+	serializer.On("Marshal", mock.Anything).Return([]byte{1}, nil)
+
+	repo := NewRepository(store, serializer)
+
+	_, err := repo.SaveTransaction(context.Background(), event)
+
+	assert.NoError(t, err)
+	assert.NotEqual(t, 0, event.Timestamp)
+}


### PR DESCRIPTION
This will allow the user of the library to define when the event happened. The ordering of the events is still based on the sequence id. This is mainly to allow users to use the timestamp field to represent when something happened, instead of being forced to include this information inside the event.

If none is set it should default to the old behavior of setting it to the time of the call to `SaveTransaction`.