### PR TITLE
Create notification client with provided SNS client

### DIFF
--- a/v2/eventsource/notification/sns/notification.go
+++ b/v2/eventsource/notification/sns/notification.go
@@ -26,6 +26,11 @@ func NewWithSession(topicARN string, sess *session.Session) eventsource.Notifica
 	return &snsNotification{topicARN, sns.New(sess)}
 }
 
+// New connection to the given SNS topic ARN, using the provided SNS client.
+func NewWithClient(topicARN string, client *sns.SNS) eventsource.NotificationService {
+	return &snsNotification{topicARN, client}
+}
+
 func (sn *snsNotification) Send(record eventsource.Record) error {
 	return sn.SendWithContext(context.Background(), record)
 }


### PR DESCRIPTION
Adds a function to initialize an SNS notification client with a provided SNS client. This can be used when specific configuration needs to be passed to the client, e.g. credentials from an assumed role.