### PR TITLE
Feature/use interface for pgxpool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,3 +75,7 @@ type Serializer interface {
 	Marshal(event Event) ([]byte, error)
 }
 ```
+
+### UUID Compatibility
+You might have to enable compatibility with our internal UUID package using an after-connect handler
+- https://github.com/SKF/go-utility/tree/master/v2/pgxcompat

--- a/v2/eventsource/stores/sqlstore/driver/pgx.go
+++ b/v2/eventsource/stores/sqlstore/driver/pgx.go
@@ -4,15 +4,19 @@ import (
 	"context"
 
 	"github.com/jackc/pgx/v4"
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 
 	"github.com/SKF/go-eventsource/v2/eventsource"
 	"github.com/SKF/go-utility/v2/uuid"
 )
 
+type PgxPool interface {
+	Begin(context.Context) (pgx.Tx, error)
+	Query(context.Context, string, ...interface{}) (pgx.Rows, error)
+}
+
 type PGX struct {
-	DB *pgxpool.Pool
+	DB PgxPool
 }
 
 func (pgx *PGX) Load(ctx context.Context, query string, args []interface{}) (records []eventsource.Record, err error) {

--- a/v2/eventsource/stores/sqlstore/store.go
+++ b/v2/eventsource/stores/sqlstore/store.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/pkg/errors"
 
 	"github.com/SKF/go-eventsource/v2/eventsource"
@@ -37,8 +36,8 @@ func New(db *sql.DB, tableName string) eventsource.Store {
 	}
 }
 
-// New creates a new event source store.
-func NewPgx(db *pgxpool.Pool, tableName string) eventsource.Store {
+// NewPgx creates a new event source store.
+func NewPgx(db driver.PgxPool, tableName string) eventsource.Store {
 	return &store{
 		db:        &driver.PGX{DB: db},
 		tablename: tableName,


### PR DESCRIPTION
Enables compatibility with https://github.com/SKF/go-utility/tree/master/v2/trace/ddpgx which prevents us from accessing the raw pgxpool implementation by using an interface instead of pgxpool.Pool.